### PR TITLE
Dockerize Application

### DIFF
--- a/flask_deployment/Dockerfile
+++ b/flask_deployment/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:2.7
+
+WORKDIR /app
+
+COPY sentiment_service.py .
+
+RUN wget https://raw.githubusercontent.com/crawles/gpdb_sentiment_analysis_twitter_model/master/twitter_sentiment_model.pkl \
+ && pip install gunicorn flask pandas sklearn
+
+EXPOSE 80
+
+CMD gunicorn --bind 0.0.0.0:80 sentiment_service:app

--- a/flask_deployment/environment.yml
+++ b/flask_deployment/environment.yml
@@ -3,7 +3,6 @@ dependencies:
   - flask
   - pandas
   - python=2.7.11
-  - requests
   - scikit-learn
   - pip:
       - gunicorn

--- a/flask_deployment/manifest.yml
+++ b/flask_deployment/manifest.yml
@@ -5,4 +5,4 @@ applications:
   disk_quota: 2GB
   instances: 1
   buildpack: https://github.com/cloudfoundry/python-buildpack.git
-  command: gunicorn --bind 0.0.0.0:$PORT sentiment_service:app
+  command: wget https://raw.githubusercontent.com/crawles/gpdb_sentiment_analysis_twitter_model/master/twitter_sentiment_model.pkl && gunicorn --bind 0.0.0.0:$PORT sentiment_service:app

--- a/flask_deployment/sentiment_service.py
+++ b/flask_deployment/sentiment_service.py
@@ -12,12 +12,10 @@ import os
 
 from flask import Flask, request, jsonify
 import pandas as pd
-import requests
 import sklearn
 
-resp = requests.get("https://raw.githubusercontent.com/crawles/gpdb_sentiment_analysis_twitter_model/master/twitter_sentiment_model.pkl")
-resp.raise_for_status()
-cl = cPickle.loads(resp.content)
+model = open("twitter_sentiment_model.pkl", "r")
+cl = cPickle.loads(model.read())
 
 def regex_preprocess(raw_tweets):
     pp_text = pd.Series(raw_tweets)


### PR DESCRIPTION
First of all, thanks for this excellent app 👌 

This adds support for Docker.

    cd flask_deployment
    docker build -t crawles/text-analytics-service .
    docker run --name text-analytics-service --rm -d -p 80:80 crawles/text-analytics-service
    curl -H "Content-Type: application/json" -X POST -d '{"data":["This app is awesome and in the CLOUD","Steph Curry is a basketball player","i am so mad and angry"]}' http://localhost/polarity_compute

The biggest change here is that I wanted to download the trained model during the image build process instead of downloading it every time the service starts. This safeguards the application in case of network failures, or if the data source (GIthub repository) goes away some day.

You can pull an image I have already pushed up to docker hub if you'd like to test: https://hub.docker.com/r/jpuck/sentiment

I tried to be as minimally invasive to the project as I could because it's been years since it's been updated and I am uncertain of the direction of the project. But I'm happy to take suggestions for changes on the PR.